### PR TITLE
Update permissions.adoc

### DIFF
--- a/docs/admin/permissions.adoc
+++ b/docs/admin/permissions.adoc
@@ -19,7 +19,7 @@ Staff Accounts
 ~~~~~~~~~~~~~~
 
 New staff accounts are created in much the same way as patron accounts, using
-_Circulation -> Register Patron_ or *Shift+F1*. Select one of the staff
+_Circulation -> Register Patron_*. Select one of the staff
 profiles 
 from the _Profile Group_ drop-down menu.
 
@@ -27,8 +27,7 @@ Each new staff account must be assigned a _Working Location_ which determines
 its 
 access level in staff client interfaces.
 
-. To assign a working location open the newly created staff account using *F1* 
-(retrieve patron) or *F4* (patron search).
+. To assign a working location, open the newly created staff account
 . Select _Other -> User Permission Editor_
 . Place a check in the box next to the desired working location, then scroll to
 the bottom of the display and click _Save_.


### PR DESCRIPTION
[Staff Accounts]
- removed hotkeys
- added a suggested screenshot for: "new staff accounts are created in much the same way as patron accounts, using Circulation → Register Patron or Shift+F1. Select one of the staff profiles from the Profile Group drop-down menu."
![1](https://user-images.githubusercontent.com/36233487/37472829-60bfd9b0-2843-11e8-99d5-7f4c624c25a8.png)
