### PR TITLE
Update recent_staff_searches.adoc

### DIFF
--- a/docs/admin/recent_staff_searches.adoc
+++ b/docs/admin/recent_staff_searches.adoc
@@ -13,6 +13,8 @@ To configure the number of recent staff searches:
 
 2. Scroll to *OPAC: Number of staff client saved searches to display on left side of results and record details pages*
 
+** new screenshot here
+
 3. Click *Edit*.
 
 4. Select a *Context* from the drop down menu.
@@ -21,7 +23,7 @@ To configure the number of recent staff searches:
 
 6. Click *Update Setting*
 
-image::media/Saved_Catalog_Searches_2_21.jpg[Saved_Catalog_Searches_2_21]
+*image::media/Saved_Catalog_Searches_2_21.jpg[Saved_Catalog_Searches_2_21]
 
 
 NOTE: To retain this setting, the system administrator must restart the web server.


### PR DESCRIPTION
- New screenshot for step "2. Scroll to *OPAC: Number of staff client saved searches to display on left side of results and record details pages*"
![saved_catalog_searches_2](https://user-images.githubusercontent.com/36233487/38931486-54324d6e-42e1-11e8-8916-3f9cd3f7f8f2.PNG)

- Updated screenshot for [Saved_Catalog_Searches_2_21]
![saved_catalog_searches_2_21](https://user-images.githubusercontent.com/36233487/38931488-5703e250-42e1-11e8-9ee1-0fe32ad2aa57.PNG)
